### PR TITLE
bugfix: Add recursive checkout functionality for git submodule update.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ UNITTEST_DIR       := tests/unittests
 UNITTEST_FILES     := $(shell find $(UNITTEST_DIR) -name '*.py')
 
 # Keep this version in sync with GITCACHE_VERSION in git_cache/git_cache_command.py
-CURRENT_VERSION    := 1.0.6
+CURRENT_VERSION    := 1.0.7
 
 
 # ----------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ gitcache is distributed as a single executable packaged using [pyInstaller].
 So all you have to do is to download the latest executable and copy it to a
 location of your choice, for example `~/bin`:
 
-    wget https://github.com/seeraven/gitcache/releases/download/v1.0.6/gitcache_v1.0.6_Ubuntu18.04_amd64
-    mv gitcache_v1.0.6_Ubuntu18.04_amd64 ~/bin/gitcache
+    wget https://github.com/seeraven/gitcache/releases/download/v1.0.7/gitcache_v1.0.7_Ubuntu18.04_amd64
+    mv gitcache_v1.0.7_Ubuntu18.04_amd64 ~/bin/gitcache
     chmod +x ~/bin/gitcache
 
 gitcache can be used as a stand-alone command, but it is much easier to use

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -14,8 +14,8 @@ gitcache on systems even if they do not provide python themselfes.
 However, the usage of gitcache is limited to the command line tool
 itself, so the integration in other scripts won't be possible::
 
-    $ wget https://github.com/seeraven/gitcache/releases/download/v1.0.6/gitcache_v1.0.6_Ubuntu18.04_amd64
-    $ mv gitcache_v1.0.6_Ubuntu18.04_amd64 /usr/local/bin/gitcache
+    $ wget https://github.com/seeraven/gitcache/releases/download/v1.0.7/gitcache_v1.0.7_Ubuntu18.04_amd64
+    $ mv gitcache_v1.0.7_Ubuntu18.04_amd64 /usr/local/bin/gitcache
     $ chmod +x /usr/local/bin/gitcache
     $ ln -s /usr/local/bin/gitcache /usr/local/bin/git
 

--- a/git_cache/git_cache_command.py
+++ b/git_cache/git_cache_command.py
@@ -54,7 +54,7 @@ If called with the first argument 'git' or when called as 'git' using a symlink,
 it acts as a wrapper for the git command and intercepts the commands required
 for the mirror handling.
 """
-GITCACHE_VERSION = "1.0.6"
+GITCACHE_VERSION = "1.0.7"
 
 
 # -----------------------------------------------------------------------------

--- a/git_cache/git_options.py
+++ b/git_cache/git_options.py
@@ -218,6 +218,7 @@ SUBMODULE_INIT_OPTIONS = []
 # Submodule update options taken from https://github.com/git/git/blob/master/git-submodule.sh
 # Only options with arguments and boolean options of interest are listed here.
 SUBMODULE_UPDATE_OPTIONS = [Option(group='init', long_name='init', has_arg=False),
+                            Option(group='recursive', long_name='recursive', has_arg=False),
                             Option(long_name='reference'),
                             Option(long_name='depth'),
                             Option(short_name='j', long_name='jobs')]

--- a/tests/functional_tests/tests/12_submodule_update.sh
+++ b/tests/functional_tests/tests/12_submodule_update.sh
@@ -93,6 +93,35 @@ test_variation multi_C  $PWD ${TMP_WORKDIR}/submodules/ -C ${TMP_WORKDIR} -C sub
 test_variation no_C     ${TMP_WORKDIR}/submodules ""
 
 
+REPO=https://github.com/aws/aws-sdk-cpp
+rm -rf ${GITCACHE_DIR}
+rm -rf ${TMP_WORKDIR}/*
+
+# Initial clone
+gitcache_ok  git clone $REPO ${TMP_WORKDIR}/aws-sdk-cpp --single-branch --branch 1.9.188
+assert_db_field mirror-updates of $REPO is 0
+assert_db_field clones of $REPO is 1
+assert_db_field updates of $REPO is 0
+
+pushd ${TMP_WORKDIR}/aws-sdk-cpp
+gitcache_ok  git submodule update --recursive --init
+assert_db_field clones of https://github.com/awslabs/aws-crt-cpp.git is 1
+assert_db_field clones of https://github.com/awslabs/aws-c-common.git is 1
+assert_db_field clones of https://github.com/awslabs/aws-c-io.git is 1
+assert_db_field clones of https://github.com/awslabs/aws-c-compression.git is 1
+assert_db_field clones of https://github.com/awslabs/aws-c-cal.git is 1
+assert_db_field clones of https://github.com/awslabs/aws-c-auth.git is 1
+assert_db_field clones of https://github.com/awslabs/aws-c-http.git is 1
+assert_db_field clones of https://github.com/awslabs/aws-c-mqtt.git is 1
+assert_db_field clones of https://github.com/awslabs/s2n.git is 1
+assert_db_field clones of https://github.com/awslabs/aws-checksums.git is 1
+assert_db_field clones of https://github.com/awslabs/aws-c-event-stream.git is 1
+assert_db_field clones of https://github.com/awslabs/aws-c-s3.git is 1
+assert_db_field clones of https://github.com/awslabs/aws-lc.git is 1
+assert_db_field clones of https://github.com/awslabs/aws-templates-for-cbmc-proofs.git is 2
+popd
+
+
 # -----------------------------------------------------------------------------
 # EOF
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
This commit adds a recursive checkout functionality for the submodule update
subcommand. This functionality was missing as discovered in issue #5.