### PR TITLE
workaround: Disable stderr capture on windows as a workaround to git for windows bug.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Upcoming Version
 
+- Workaround: Git for Windows has a bug preventing asking for a password when stderr is redirected
+  (see https://github.com/git-for-windows/git/issues/1613). As a workaround, we disable stderr
+  capture (and analysis) if we find the pattern "Permission denied (publickey)." in stderr.
+
 ## v1.0.14
 
 - Bugfix: Fixed relative submodule URLs (thanks to Ihor Dutchak)


### PR DESCRIPTION
This change is a workaround for a bug of git for windows: When `stderr` is redirected, git for windows fails to detect the console and is unable to prompt for a password.

The workaround solves this problem by checking the output (only on Windows) and if an error with the public key authentication is detected, it executes the following retries without a redirection of `stderr`. This also disables the ability to monitor the progress and therefore the output timeout, but since the full timeout is still in place it should be manageable.

This change closes issue #31.