### PR TITLE
Add x86_64 binaries as part of release package

### DIFF
--- a/.github/workflows/create_release.yaml
+++ b/.github/workflows/create_release.yaml
@@ -102,7 +102,7 @@ jobs:
           path: |
             releases
 
-  build-macos:
+  build-macos-arm64:
     runs-on: macos-14
     steps:
       - name: Check out repository code
@@ -121,7 +121,32 @@ jobs:
       - name: Create Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: release-macos
+          name: release-macos-arm64
+          retention-days: 1
+          overwrite: true
+          path: |
+            releases/*.tgz
+
+  build-macos-x86_64:
+    runs-on: macos-13
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Install dependencies
+        run: |
+          brew install make git-lfs
+      - name: Build Release
+        run: |
+          make current-release
+      - name: Test Release
+        run: |
+          make test-current-release
+      - name: Create Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-macos-x86_64
           retention-days: 1
           overwrite: true
           path: |
@@ -129,7 +154,7 @@ jobs:
 
   create_release:
     runs-on: ubuntu-latest
-    needs: [build-ubuntu-2004, build-ubuntu-2204, build-windows-2022, build-macos]
+    needs: [build-ubuntu-2004, build-ubuntu-2204, build-windows-2022, build-macos-arm64, build-macos-x86_64]
     steps:
       - name: Get artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -76,8 +76,11 @@ jobs:
         run: |
           C:\ProgramData\chocolatey\bin\make tests
 
-  macos-14:
-    runs-on: macos-14
+  macos:
+    strategy:
+      matrix:
+        os: [macos-13, macos-14]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4

--- a/.github/workflows/on_push.yaml
+++ b/.github/workflows/on_push.yaml
@@ -65,7 +65,7 @@ jobs:
         run: |
           C:\ProgramData\chocolatey\bin\make
 
-  macos-14:
+  macos:
     strategy:
       matrix:
         os: [macos-13, macos-14]

--- a/.github/workflows/on_push.yaml
+++ b/.github/workflows/on_push.yaml
@@ -66,7 +66,10 @@ jobs:
           C:\ProgramData\chocolatey\bin\make
 
   macos-14:
-    runs-on: macos-14
+    strategy:
+      matrix:
+        os: [macos-13, macos-14]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4

--- a/.github/workflows/pip_deps_upgrade_macos.yaml
+++ b/.github/workflows/pip_deps_upgrade_macos.yaml
@@ -22,6 +22,7 @@ on:
 jobs:
   macos:
     strategy:
+      fail-fast: false
       matrix:
         os: [macos-13, macos-14]
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/pip_deps_upgrade_macos.yaml
+++ b/.github/workflows/pip_deps_upgrade_macos.yaml
@@ -20,8 +20,11 @@ on:
         type: string
 
 jobs:
-  macos-14:
-    runs-on: macos-14
+  macos:
+    strategy:
+      matrix:
+        os: [macos-13, macos-14]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4

--- a/.github/workflows/pip_deps_upgrade_macos.yaml
+++ b/.github/workflows/pip_deps_upgrade_macos.yaml
@@ -42,7 +42,7 @@ jobs:
         with:
           commit-message: "${{ inputs.commit_message }}"
           committer: "${{ inputs.committer }}"
-          branch: "feature/update-macos-pip-deps"
-          title: "Update MacOS Pip-Dependencies"
+          branch: "feature/update-macos-pip-deps-${{ matrix.os }}"
+          title: "Update MacOS Pip-Dependencies (${{ matrix.os }})"
           assignees: "seeraven"
           reviewers: "seeraven"


### PR DESCRIPTION
Github Actions macOS-13 Runner is x86_64 machine, as opposed to macOS-14 which is ARM64.