### PR TITLE
bugfix: wrong arch name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ gitcache is distributed as a single executable packaged using [pyInstaller].
 So all you have to do is to download the latest executable and copy it to a
 location of your choice, for example `~/bin`:
 
-    wget https://github.com/seeraven/gitcache/releases/download/v1.0.21/gitcache_v1.0.21_Ubuntu22.04_amd64
-    mv gitcache_v1.0.21_Ubuntu22.04_amd64 ~/bin/gitcache
+    wget https://github.com/seeraven/gitcache/releases/download/v1.0.21/gitcache_v1.0.21_Ubuntu22.04_x86_64
+    mv gitcache_v1.0.21_Ubuntu22.04_x86_64 ~/bin/gitcache
     chmod +x ~/bin/gitcache
 
 gitcache can be used as a stand-alone command, but it is much easier to use


### PR DESCRIPTION
The releases available are x86_64, not amd64