### PR TITLE
Potential fix for code scanning alert no. 16: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/create_release.yaml
+++ b/.github/workflows/create_release.yaml
@@ -171,6 +171,8 @@ jobs:
   create_release:
     runs-on: ubuntu-latest
     needs: [build-wheel, build-ubuntu, build-alpine, build-windows-2022, build-macos]
+    permissions:
+      contents: write
     steps:
       - name: Get artifacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
Potential fix for [https://github.com/seeraven/gitcache/security/code-scanning/16](https://github.com/seeraven/gitcache/security/code-scanning/16)

To fix the issue, we need to add a `permissions` block to the `create_release` job to explicitly define the least privileges required for the job. Since the job uses the `GITHUB_TOKEN` to create a release, it likely requires `contents: write` permission. Other permissions should be set to `none` unless explicitly required.

The `permissions` block should be added directly under the `create_release` job definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
