### PR TITLE
bugfix: fix path not exists in database;

### DIFF
--- a/src/git_cache/global_settings.py
+++ b/src/git_cache/global_settings.py
@@ -43,7 +43,7 @@ import os
 # -----------------------------------------------------------------------------
 # Settings
 # -----------------------------------------------------------------------------
-GITCACHE_DIR = os.getenv("GITCACHE_DIR", os.path.join(os.getenv("HOME", "/"), ".gitcache"))
+GITCACHE_DIR = os.path.normpath(os.getenv("GITCACHE_DIR", os.path.join(os.getenv("HOME", "/"), ".gitcache")))
 GITCACHE_DB = os.path.join(GITCACHE_DIR, "db")
 GITCACHE_DB_LOCK = os.path.join(GITCACHE_DIR, "db.lock")
 GITCACHE_LOGLEVEL = os.getenv("GITCACHE_LOGLEVEL", "INFO")


### PR DESCRIPTION
fix [#105](https://github.com/seeraven/gitcache/issues/105)

If GITCACHE_DIR is not normalized, database functions will not be able to find the path in the database.