### PR TITLE
feature: Support shallow clone from mirror directory with the --depth option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Feature: Use relative paths in database.
 - Bugfix: Ensure `GITCACHE_DIR` is normalized (thanks to guoh27)
+- Feature: Support shallow cloning from local mirror with the `--depth` option
 
 ## v1.0.28
 

--- a/src/git_cache/commands/helpers.py
+++ b/src/git_cache/commands/helpers.py
@@ -60,7 +60,7 @@ def get_mirror_url(git_options):
         a mirror.
     """
     pull_url = get_pull_url(git_options)
-    if pull_url and pull_url.startswith(GITCACHE_DIR):
+    if pull_url and (pull_url.startswith(GITCACHE_DIR) or pull_url.startswith(f"file://{GITCACHE_DIR}")):
         command = git_options.get_real_git_with_options()
         command += ["remote", "get-url", "--push", "origin"]
         retval, push_url = getstatusoutput(command)

--- a/src/git_cache/git_mirror.py
+++ b/src/git_cache/git_mirror.py
@@ -325,7 +325,7 @@ class GitMirror:
         git_lfs_url = self.url + "/info/lfs"
         real_git = self.config.get("System", "RealGit")
 
-        new_args = [x if x != self.url else self.git_dir for x in git_options.all_args]
+        new_args = [x if x != self.url else f"file://{self.git_dir}" for x in git_options.all_args]
         for option in ["--recursive", "--recurse-submodules", "--remote-submodules"]:
             if option in new_args:
                 new_args.remove(option)

--- a/test/functional_tests/helpers/gitcache_ifc.py
+++ b/test/functional_tests/helpers/gitcache_ifc.py
@@ -135,6 +135,12 @@ class GitcacheIfc:
         result = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, shell=False, check=True)
         return result.stdout.decode().strip()
 
+    def get_depth(self, checkout_dir: str) -> int:
+        """Get the depth of the given checkout directory as the number of entries in the log."""
+        command = ["git", "-C", checkout_dir, "log", "--pretty=format:%h", "-n", "100"]
+        result = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, shell=False, check=True)
+        return len(result.stdout.decode().strip().split())
+
     def get_tag(self, checkout_dir: str) -> str:
         """Get the current tag of the given checkout directory."""
         command = ["git", "-C", checkout_dir, "describe", "--tags"]
@@ -143,7 +149,9 @@ class GitcacheIfc:
 
     def remote_points_to_gitcache(self, checkout_dir: str) -> bool:
         """Check if the remote of the given checkout directory points to the gitcache dir."""
-        return self.get_remote(checkout_dir).startswith(self.workspace.gitcache_dir_path)
+        return self.get_remote(checkout_dir).startswith(self.workspace.gitcache_dir_path) or self.get_remote(
+            checkout_dir
+        ).startswith(f"file://{self.workspace.gitcache_dir_path}")
 
     def str_in_file(self, needle: bytes, filename: str) -> bool:
         """Check for the given needle string in the file."""

--- a/test/functional_tests/test_10_clone.py
+++ b/test/functional_tests/test_10_clone.py
@@ -97,6 +97,21 @@ def test_clone_branch(gitcache_ifc: GitcacheIfc):
     assert branch == gitcache_ifc.get_branch(checkout)
 
 
+def test_clone_depth(gitcache_ifc: GitcacheIfc):
+    """Test cloning a repository with a limited depth."""
+    repo = "https://github.com/seeraven/gitcache"
+    checkout = os.path.join(gitcache_ifc.workspace.workspace_path, "gitcache")
+    gitcache_ifc.run_ok(["git", "-C", gitcache_ifc.workspace.workspace_path, "clone", repo])
+    full_depth = gitcache_ifc.get_depth(checkout)
+
+    checkout = os.path.join(gitcache_ifc.workspace.workspace_path, "gitcache2")
+    gitcache_ifc.run_ok(["git", "clone", "--depth", "1", repo, checkout])
+    limited_depth = gitcache_ifc.get_depth(checkout)
+    assert limited_depth < full_depth
+    assert 1 == gitcache_ifc.db_field("mirror-updates", repo)
+    assert 2 == gitcache_ifc.db_field("clones", repo)
+
+
 def test_clone_tag(gitcache_ifc: GitcacheIfc):
     """Test cloning an explicit tag."""
     repo = "https://github.com/seeraven/scm-autologin-plugin"


### PR DESCRIPTION
The `--depth` option is only supported by git when using the `file://` syntax when referencing a local directory. This commit modifies gitcache to use this syntax when refering to the mirror directory and thus enables the support for the `--depth` option.

Fixes #113