### PR TITLE
bugfix: fix LFS endpoint normalization for URLs without .git

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Upcoming version
 
+- Bugfix: Normalize explicit `lfs.url` for HTTP(S)/FTP(S) remotes to the canonical `<repo>.git/info/lfs` endpoint.
+  This fixes broken LFS auth flows when clone URLs omit `.git` (seen on GHES) while keeping SSH/SCP/file-style remotes unchanged.
+
 ## v1.0.33
 
 - Bugfix: Avoid database destruction when disc-is-full.

--- a/src/git_cache/git_mirror.py
+++ b/src/git_cache/git_mirror.py
@@ -286,9 +286,11 @@ class GitMirror:
     def get_lfs_url(self):
         """Get the LFS URL for the upstream repository.
 
-        For HTTP(S) and FTP(S) URLs, this appends '/info/lfs' to the URL.
-        For SSH URLs (both protocol and SCP-style), returns the original
-        URL so git-lfs can handle server discovery on its own.
+        For HTTP(S) and FTP(S) URLs, this derives the LFS batch endpoint the
+        same way git-lfs does, i.e. '<repo>.git/info/lfs', regardless of
+        whether the clone URL carries a '.git' suffix. For SSH URLs (both
+        protocol and SCP-style), returns the original URL so git-lfs can
+        handle server discovery on its own.
 
         Return:
             Returns the LFS URL string.
@@ -296,8 +298,36 @@ class GitMirror:
         if match := RE_URL_WITH_PROTO.match(self.url):
             proto = match.group(1).lower()
             if proto in ("http", "https", "ftp", "ftps"):
-                return self.url + "/info/lfs"
+                return self.normalize_lfs_endpoint(self.url)
         return self.url
+
+    @staticmethod
+    def normalize_lfs_endpoint(url: str) -> str:
+        """Derive the canonical Git-LFS batch endpoint for the given URL.
+
+        git-lfs derives the LFS endpoint by appending '/info/lfs' to the
+        repository URL including its '.git' segment, e.g.
+        '<repo>.git/info/lfs'. gitcache previously appended '/info/lfs'
+        without inserting the '.git' segment, which for clone URLs lacking a
+        '.git' suffix produced a broken endpoint that the server answers with
+        a 302 redirect to /login (surfaced as an Authorization error). This
+        normalizes the trailing slash, ensures exactly one '.git' segment and
+        then appends '/info/lfs' so the result is correct for both '<repo>'
+        and '<repo>.git' input URLs.
+
+        Args:
+            url (str): The repository URL (http(s)/ftp(s)).
+
+        Return:
+            Returns the normalized '<repo>.git/info/lfs' endpoint.
+        """
+        url = url.rstrip("/")
+        if url.endswith("/info/lfs"):
+            url = url[: -len("/info/lfs")]
+        url = url.rstrip("/")
+        if url.endswith(".git"):
+            url = url[:-4]
+        return f"{url}.git/info/lfs"
 
     def configure_git_for_mirror(self, git_options: GitOptions) -> int:
         """Configure the local git repository to use the mirror."""

--- a/test/unittests/test_git_cache_git_mirror_normalize_lfs_endpoint.py
+++ b/test/unittests/test_git_cache_git_mirror_normalize_lfs_endpoint.py
@@ -1,0 +1,69 @@
+#
+# Copyright (c) 2026 by Clemens Rabe <clemens.rabe@clemensrabe.de>
+# All rights reserved.
+# This file is part of gitcache (https://github.com/seeraven/gitcache)
+# and is released under the "BSD 3-Clause License". Please see the LICENSE file
+# that is included as part of this package.
+#
+"""Unit tests of the git_cache.git_mirror module testing normalize_lfs_endpoint()."""
+
+# -----------------------------------------------------------------------------
+# Module Import
+# -----------------------------------------------------------------------------
+from unittest import TestCase
+
+from git_cache.git_mirror import GitMirror
+
+
+# -----------------------------------------------------------------------------
+# Test Class
+# -----------------------------------------------------------------------------
+class GitCacheNormalizeLfsEndpointTest(TestCase):
+    """Test the :func:`git_cache.git_mirror.GitMirror.normalize_lfs_endpoint` function."""
+
+    def test_normalize_lfs_endpoint(self):
+        """git_cache.git_mirror.GitMirror.normalize_lfs_endpoint(): Test the function."""
+        expected = "https://github.com/org/repo.git/info/lfs"
+
+        # URL without a .git suffix gets one inserted.
+        self.assertEqual(GitMirror.normalize_lfs_endpoint("https://github.com/org/repo"), expected)
+
+        # URL already carrying a .git suffix is not doubled.
+        self.assertEqual(GitMirror.normalize_lfs_endpoint("https://github.com/org/repo.git"), expected)
+
+        # Trailing slashes are stripped.
+        self.assertEqual(GitMirror.normalize_lfs_endpoint("https://github.com/org/repo/"), expected)
+        self.assertEqual(GitMirror.normalize_lfs_endpoint("https://github.com/org/repo.git/"), expected)
+
+        # An already-canonical endpoint is idempotent.
+        self.assertEqual(GitMirror.normalize_lfs_endpoint(expected), expected)
+        self.assertEqual(GitMirror.normalize_lfs_endpoint("https://github.com/org/repo/info/lfs"), expected)
+
+    def test_get_lfs_url_protocol_scope(self):
+        """git_cache.git_mirror.GitMirror.get_lfs_url(): normalize only HTTP(S)/FTP(S)."""
+        mirror = GitMirror.__new__(GitMirror)
+
+        # HTTP(S)/FTP(S): force canonical '.git/info/lfs'.
+        mirror.url = "https://github.com/org/repo"
+        self.assertEqual(mirror.get_lfs_url(), "https://github.com/org/repo.git/info/lfs")
+
+        mirror.url = "ftp://example.com/org/repo"
+        self.assertEqual(mirror.get_lfs_url(), "ftp://example.com/org/repo.git/info/lfs")
+
+        # SSH/SCP/file/local paths: keep input unchanged.
+        mirror.url = "ssh://git@github.com/org/repo.git"
+        self.assertEqual(mirror.get_lfs_url(), "ssh://git@github.com/org/repo.git")
+
+        mirror.url = "git@github.com:org/repo.git"
+        self.assertEqual(mirror.get_lfs_url(), "git@github.com:org/repo.git")
+
+        mirror.url = "file:///tmp/repo.git"
+        self.assertEqual(mirror.get_lfs_url(), "file:///tmp/repo.git")
+
+        mirror.url = "/tmp/repo.git"
+        self.assertEqual(mirror.get_lfs_url(), "/tmp/repo.git")
+
+
+# -----------------------------------------------------------------------------
+# EOF
+# -----------------------------------------------------------------------------


### PR DESCRIPTION
Normalize explicit `lfs.url` for HTTP(S)/FTP(S) remotes to the canonical `<repo>.git/info/lfs` endpoint.


This fixes broken LFS auth flows when clone URLs omit `.git` (seen on GHES) while keeping SSH/SCP/file-style remotes unchanged.